### PR TITLE
Always create an executable with its arch suffix.

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -12,27 +12,28 @@ fi
 LINKFLAGS="-X main.Version=$VERSION"
 LINKFLAGS="-X main.GitCommit=$COMMIT $LINKFLAGS"
 
-case "$ARCH" in
-  amd64) XARCH=arm64 ; THIS_SUFFIX="" ; X_SUFFIX="-arm64" ;;
-  arm64) XARCH=amd64 ; THIS_SUFFIX="-arm64" ; X_SUFFIX="" ;;
-  *) echo "Unsupported ARCH of $ARCH" 1>&2 ; exit 1
-esac
 
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator${THIS_SUFFIX}"
-
-# Set CROSS to build for other platforms
-if [ "$CROSS" = "true" ]; then
-  for OS in darwin windows ; do
-        GOOS=$OS go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-$OS${THIS_SUFFIX}"
-  done
+ARCHES=( "$ARCH" )
+# Set CROSS_ARCH to build for the other architecture
+if [ "$CROSS_ARCH" == "true" ]; then
+  case "$ARCH" in
+    amd64) XARCH=arm64 ;;
+    arm64) XARCH=amd64 ;;
+    *) echo "Unsupported ARCH of $ARCH" 1>&2 ; exit 1
+  esac
+  ARCHES+=( "$XARCH" )
 fi
 
-# Set CROSS_ARCH to build for other architectures (one only currently)
-if [ "$CROSS_ARCH" == "true" ]; then
-  GOARCH=$XARCH CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator${X_SUFFIX}"
+for A in "${ARCHES[@]}" ; do
+  GOARCH="$A" CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator-$A"
+  # Set CROSS to build for other OS'es
   if [ "$CROSS" = "true" ]; then
     for OS in darwin windows ; do
-      GOARCH=$XARCH GOOS=$OS go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-${OS}${X_SUFFIX}"
+          GOARCH="$A" GOOS=$OS go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-$OS-$A"
     done
   fi
-fi
+done
+
+cd bin
+ln -sf "./backup-restore-operator-$ARCH" "./backup-restore-operator"
+cd ..


### PR DESCRIPTION
And then create a symlink to the suffix-less form
on the current architecture.